### PR TITLE
Fix fatal errors when loading the pdb due to an HTTPS redirect

### DIFF
--- a/src/FixPluginTypesSerialization/Util/MiniPdbReader.cs
+++ b/src/FixPluginTypesSerialization/Util/MiniPdbReader.cs
@@ -96,7 +96,7 @@ namespace FixPluginTypesSerialization.Util
 
         private bool DownloadUnityPdb(PeReader peReader)
         {
-            const string unitySymbolServer = "http://symbolserver.unity3d.com";
+            const string unitySymbolServer = "https://symbolserver.unity3d.com";
 
             var pdbCompressedPath = peReader.RsdsPdbFileName.TrimEnd('b') + '_';
             var pdbDownloadUrl = $"{unitySymbolServer}/{peReader.RsdsPdbFileName}/{peReader.PdbGuid}/{pdbCompressedPath}";


### PR DESCRIPTION
The symbol server seems to have recently changed so that it only allows connections via HTTPS, causing errors whenever the patcher tries to download symbols. Changing the URL to point to HTTPS fixes this.